### PR TITLE
Add support for all newlines

### DIFF
--- a/keymaps/blackspace.cson
+++ b/keymaps/blackspace.cson
@@ -9,3 +9,13 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor:not(.mini)':
   'enter': 'blackspace:strip-auto-whitespace'
+
+'.platform-darwin atom-text-editor:not(.mini)':
+  'shift-enter': 'blackspace:strip-auto-whitespace'
+  'cmd-enter': 'blackspace:strip-auto-whitespace'
+  'alt-enter': 'blackspace:strip-auto-whitespace'
+
+'.platform-win32 atom-text-editor:not(.mini), .platform-linux atom-text-editor:not(.mini)':
+  'shift-enter': 'blackspace:strip-auto-whitespace'
+  'ctrl-enter': 'blackspace:strip-auto-whitespace'
+  'alt-enter': 'blackspace:strip-auto-whitespace'

--- a/keymaps/blackspace.cson
+++ b/keymaps/blackspace.cson
@@ -8,14 +8,14 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor:not(.mini)':
-  'enter': 'blackspace:strip-auto-whitespace'
+  'enter': 'blackspace:newline'
 
 '.platform-darwin atom-text-editor:not(.mini)':
-  'shift-enter': 'blackspace:strip-auto-whitespace'
-  'cmd-enter': 'blackspace:strip-auto-whitespace'
-  'alt-enter': 'blackspace:strip-auto-whitespace'
+  'shift-enter': 'blackspace:newline'
+  'cmd-enter': 'blackspace:newline'
+  'alt-enter': 'blackspace:newline'
 
 '.platform-win32 atom-text-editor:not(.mini), .platform-linux atom-text-editor:not(.mini)':
-  'shift-enter': 'blackspace:strip-auto-whitespace'
-  'ctrl-enter': 'blackspace:strip-auto-whitespace'
-  'alt-enter': 'blackspace:strip-auto-whitespace'
+  'shift-enter': 'blackspace:newline'
+  'ctrl-enter': 'blackspace:newline'
+  'alt-enter': 'blackspace:newline'

--- a/keymaps/blackspace.cson
+++ b/keymaps/blackspace.cson
@@ -14,8 +14,10 @@
   'shift-enter': 'blackspace:newline'
   'cmd-enter': 'blackspace:newline'
   'alt-enter': 'blackspace:newline'
+  'shift-cmd-enter': 'blackspace:newline-above'
 
 '.platform-win32 atom-text-editor:not(.mini), .platform-linux atom-text-editor:not(.mini)':
   'shift-enter': 'blackspace:newline'
   'ctrl-enter': 'blackspace:newline'
   'alt-enter': 'blackspace:newline'
+  'ctrl-shift-enter': 'blackspace:newline-above'

--- a/lib/blackspace.coffee
+++ b/lib/blackspace.coffee
@@ -6,9 +6,9 @@ class Blackspace
   constructor: (atom) ->
     @atom = atom
     @atom.commands.add 'atom-text-editor',
-      'blackspace:strip-auto-whitespace': (e) => @strip(e)
+      'blackspace:newline': (e) => @newline(e)
 
-  strip: (e) ->
+  newline: (e) ->
     editor = @atom.workspace.getActiveTextEditor()
     buffer = editor.getBuffer()
     cursor = editor.getLastCursor()

--- a/lib/blackspace.coffee
+++ b/lib/blackspace.coffee
@@ -7,8 +7,9 @@ class Blackspace
     @atom = atom
     @atom.commands.add 'atom-text-editor',
       'blackspace:newline': (e) => @newline(e)
+      'blackspace:newline-above': (e) => @newline(e, {above: true})
 
-  newline: (e) ->
+  newline: (e, {above}={}) ->
     editor = @atom.workspace.getActiveTextEditor()
     buffer = editor.getBuffer()
     cursor = editor.getLastCursor()
@@ -18,6 +19,11 @@ class Blackspace
         rowRange = buffer.rangeForRow(currentRow, false)
         rowText = editor.getTextInBufferRange(rowRange)
         editor.setTextInBufferRange(rowRange, '')
-        editor.insertText("\n" + rowText, {autoIndent: false})
+        if above
+          editor.insertText(rowText + "\n", {autoIndent: false})
+          cursor.moveUp()
+          cursor.moveToEndOfLine()
+        else
+          editor.insertText("\n" + rowText, {autoIndent: false})
     else
       e.abortKeyBinding()

--- a/spec/blackspace-spec.coffee
+++ b/spec/blackspace-spec.coffee
@@ -19,7 +19,7 @@ describe 'Blackspace', ->
   it 'moves the (auto inserted) whitespace from a blank line to the next line', ->
     editor = atom.workspace.getActiveTextEditor()
     editor.setText("  hello\n  ")
-    atom.commands.dispatch(atom.views.getView(editor), 'blackspace:strip-auto-whitespace')
+    atom.commands.dispatch(atom.views.getView(editor), 'blackspace:newline')
     bufferText = editor.getText()
     bufferText = bufferText.replace(/\n/g, '=').replace(/\s/g, '-')
     expect(bufferText).toBe("--hello==--")

--- a/spec/blackspace-spec.coffee
+++ b/spec/blackspace-spec.coffee
@@ -16,10 +16,26 @@ describe 'Blackspace', ->
     waitsForPromise ->
       atom.packages.activatePackage('blackspace')
 
-  it 'moves the (auto inserted) whitespace from a blank line to the next line', ->
-    editor = atom.workspace.getActiveTextEditor()
-    editor.setText("  hello\n  ")
-    atom.commands.dispatch(atom.views.getView(editor), 'blackspace:newline')
-    bufferText = editor.getText()
-    bufferText = bufferText.replace(/\n/g, '=').replace(/\s/g, '-')
-    expect(bufferText).toBe("--hello==--")
+  describe 'newline', ->
+    it 'moves the (auto inserted) whitespace from a blank line to the next line', ->
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setText("  hello\n  ")
+      atom.commands.dispatch(atom.views.getView(editor), 'blackspace:newline')
+      cursor = editor.getLastCursor()
+      bufferText = editor.getText()
+      bufferText = bufferText.replace(/\n/g, '=').replace(/\s/g, '-')
+      expect(bufferText).toBe("--hello==--")
+      expect(cursor.getBufferRow()).toBe 2
+      expect(cursor.getBufferColumn()).toBe 2
+
+  describe 'newline-above', ->
+    it 'moves the (auto inserted) whitespace from a blank line to the line above', ->
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setText("  hello\n  ")
+      atom.commands.dispatch(atom.views.getView(editor), 'blackspace:newline-above')
+      cursor = editor.getLastCursor()
+      bufferText = editor.getText()
+      bufferText = bufferText.replace(/\n/g, '=').replace(/\s/g, '-')
+      expect(bufferText).toBe("--hello=--=")
+      expect(cursor.getBufferRow()).toBe 1
+      expect(cursor.getBufferColumn()).toBe 2


### PR DESCRIPTION
This adds support for all types of newlines, even the `newlines-above` command (cmd-shift-enter) mentioned in #1.
